### PR TITLE
3DS Max: clean up

### DIFF
--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.AbstractMesh.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.AbstractMesh.cs
@@ -20,7 +20,6 @@ namespace Max2Babylon
             gltfNode.name = GetUniqueNodeName(babylonAbstractMesh.name);
             gltfNode.index = gltf.NodesList.Count;
             gltf.NodesList.Add(gltfNode);
-            nodeToGltfNodeMap.Add(babylonAbstractMesh, gltfNode);
 
             // Hierarchy
             if (gltfParentNode != null)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Camera.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Camera.cs
@@ -19,7 +19,6 @@ namespace Max2Babylon
             gltfNode.name = GetUniqueNodeName(babylonCamera.name);
             gltfNode.index = gltf.NodesList.Count;
             gltf.NodesList.Add(gltfNode);
-            nodeToGltfNodeMap.Add(babylonCamera, gltfNode);
 
             // Hierarchy
             if (gltfParentNode != null)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Light.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Light.cs
@@ -19,7 +19,6 @@ namespace Max2Babylon
             gltfNode.name = GetUniqueNodeName(babylonLight.name);
             gltfNode.index = gltf.NodesList.Count;
             gltf.NodesList.Add(gltfNode);
-            nodeToGltfNodeMap.Add(babylonLight, gltfNode);
 
             // Hierarchy
             if (gltfParentNode != null)

--- a/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Skin.cs
+++ b/3ds Max/Max2Babylon/Exporter/BabylonExporter.GLTFExporter.Skin.cs
@@ -1,6 +1,7 @@
 ﻿using BabylonExport.Entities;
 using GLTFExport.Entities;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Max2Babylon
@@ -137,9 +138,16 @@ namespace Max2Babylon
 
         private GLTFNode _exportBone(BabylonBone babylonBone, GLTF gltf, BabylonSkeleton babylonSkeleton, List<BabylonBone> bones)
         {
-            if (alreadyExportedNodes.ContainsKey(babylonBone.id))
+            var nodeNodePair = nodeToGltfNodeMap.FirstOrDefault(pair => pair.Key.id.Equals(babylonBone.id));
+            if (nodeNodePair.Key != null)
             {
-                return alreadyExportedNodes[babylonBone.id];
+                return nodeNodePair.Value;
+            }
+
+            var boneNodePair = boneToGltfNodeMap.FirstOrDefault(pair => pair.Key.id.Equals(babylonBone.id));
+            if (boneNodePair.Key != null)
+            {
+                return boneNodePair.Value;
             }
 
             // Node
@@ -150,7 +158,6 @@ namespace Max2Babylon
             };
             gltf.NodesList.Add(gltfNode);
             
-            alreadyExportedNodes.Add(babylonBone.id, gltfNode);
             boneToGltfNodeMap.Add(babylonBone, gltfNode);
 
             // Hierarchy

--- a/SharedProjects/BabylonExport.Entities/BabylonBone.cs
+++ b/SharedProjects/BabylonExport.Entities/BabylonBone.cs
@@ -22,9 +22,6 @@ namespace BabylonExport.Entities
         [DataMember]
         public BabylonAnimation animation { get; set; }
 
-        [DataMember]
-        public string id { get; set; }
-
         public BabylonBone()
         {
             parentBoneIndex = -1;


### PR DESCRIPTION
3DS Max: clean up
- Remove the `nodeToGltfNodeMap` property that is redundant with `nodeToGltfNodeMap` and `boneToGltfNodeMap`